### PR TITLE
Skip over action buttons when tabbing

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -85,7 +85,8 @@
                 buttonToggle = '',
                 buttonHandler = ns+'-'+button.name,
                 btnText = button.btnText ? button.btnText : '',
-                btnClass = button.btnClass ? button.btnClass : 'btn'
+                btnClass = button.btnClass ? button.btnClass : 'btn',
+                tabIndex = button.tabIndex ? button.tabIndex : '-1'
 
             if (button.toggle == true) {
               buttonToggle = ' data-toggle="button"'
@@ -96,6 +97,8 @@
                                     +btnClass
                                     +' btn-small" title="'
                                     +button.title
+                                    +'" tabindex="'
+                                    +tabIndex
                                     +'" data-provider="'
                                     +ns
                                     +'" data-handler="'


### PR DESCRIPTION
Currently, tabbing through a form will select each button for bootstrap-markdown before the user gets to the textarea, which results in a bunch of unnecessary tabs for the end user.

This could be fixed by setting `tabindex="-1"` for each button.
