### PR TITLE
Option for other icon libraries

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -84,7 +84,7 @@
             var button = buttons[z],
                 buttonToggle = '',
                 buttonHandler = ns+'-'+button.name,
-                buttonIcon = button.icon instanceof Object ? button.icon[this.$options.iconLibrary] : button.icon,
+                buttonIcon = button.icon instanceof Object ? button.icon[this.$options.iconlibrary] : button.icon,
                 btnText = button.btnText ? button.btnText : '',
                 btnClass = button.btnClass ? button.btnClass : 'btn',
                 tabIndex = button.tabIndex ? button.tabIndex : '-1'
@@ -671,7 +671,7 @@
     savable:false,
     width: 'inherit',
     height: 'inherit',
-    iconLibrary: 'glyph',
+    iconlibrary: 'glyph',
 
     /* Buttons Properties */
     buttons: [


### PR DESCRIPTION
Glyphicons are great and all, but I know multiple websites use other icon libraries (most commonly Font Awesome). Simple implementation:

**Old icon syntax**
icon: 'glyphicon glyphicon-bold'

**New icon syntax**
icon: { glyph: 'glyphicon glyphicon-bold', fa: 'fa fa-bold' }

**Choosing icon library**
The default icon library is glyphicons, as that is the default with Bootstrap. Too change to Font Awesome, for example:
$('textarea').markdown({iconLibrary: 'fa'})

Of course, still backwards compatible with the old syntax.
