### PR TITLE
Reset margin of .md-header

### DIFF
--- a/less/bootstrap-markdown.less
+++ b/less/bootstrap-markdown.less
@@ -18,6 +18,10 @@
     background: @panel-default-heading-bg;
   }
 
+  > .md-header {
+    margin: 0;
+  }
+
   > .md-preview {
     background: @panel-bg;
     border-top: 1px dashed @table-border-color;


### PR DESCRIPTION
This is required in order for the header to look ok when using
Bootstrap 3.1.x.

Not sure if this is the correct fix though.
