### PR TITLE
Upgrade to Bootstrap 3.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "2.2.1",
   "main": ["./js/bootstrap-markdown.js", "./css/bootstrap-markdown.min.css"],
   "dependencies": {
-    "bootstrap": "~3.0.0"
+    "bootstrap": "~3.1.1"
   },
   "devDependencies": {
   	"markdown":"~0.4.0"


### PR DESCRIPTION
Use Bootstrap 3.1.x. #39 is required to be applied or misalignment of the markdown header appears.
