### PR TITLE
Add an option to rearrange all the buttons and group buttons

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -193,14 +193,58 @@
                             'class': 'md-header btn-toolbar'
                             })
 
-        // Build the main buttons
+        // Merge the main & additional buttons together
+        var allButtons = []
         if (options.buttons.length > 0) {
-          editorHeader = this.__buildButtons(options.buttons, editorHeader)
+          allButtons = allButtons.concat(options.buttons[0])
+        }
+        if (options.additionalButtons.length > 0) {
+          allButtons = allButtons.concat(options.additionalButtons[0])
         }
 
-        // Build the additional buttons
-        if (options.additionalButtons.length > 0) {
-          editorHeader = this.__buildButtons(options.additionalButtons, editorHeader)
+        if (options.rearrangeButtons.length > 0) {
+
+          // Build the rearranged buttons
+          for (var i = 0, iLength = options.rearrangeButtons.length; i < iLength; i++) {
+            var flattenButtons
+
+            if (typeof options.rearrangeButtons[i] === 'string') {
+              for (var j = 0, jLength = allButtons.length; j < jLength; j++) {
+                if (options.rearrangeButtons[i] === allButtons[j].name) {
+                  editorHeader = this.__buildButtons([[allButtons[j]]], editorHeader)
+                  break
+                }
+              }
+            }
+
+            if (typeof options.rearrangeButtons[i] === 'object') {
+              if (!flattenButtons) {
+                flattenButtons = [].concat.apply([], allButtons.map(function (obj) {return obj.data}))
+              }
+
+              var obj = options.rearrangeButtons[i],
+                  btnGroup = {
+                    name: Object.keys(obj)[0],
+                    data: []
+                  },
+                  btnNamesArr = options.rearrangeButtons[i][btnGroup.name]
+
+              for (var k = 0, kLength = btnNamesArr.length; k < kLength; k++) {
+                for (var l = 0, lLength = flattenButtons.length; l < lLength; l++) {
+                  if (flattenButtons[l].name === btnNamesArr[k]) {
+                    btnGroup.data = btnGroup.data.concat(flattenButtons[l])
+                    break
+                  }
+                }
+              }
+
+              editorHeader = this.__buildButtons([[btnGroup]], editorHeader)
+            }
+          }
+        } else {
+
+          // Build the buttons in the default order
+          editorHeader = this.__buildButtons([allButtons], editorHeader)
         }
 
         editor.append(editorHeader)
@@ -908,6 +952,7 @@
       }]
     ],
     additionalButtons:[], // Place to hook more buttons by code
+    rearrangeButtons:[],  // Option to rearrange all the buttons and group buttons
 
     /* Events hook */
     onShow: function (e) {},


### PR DESCRIPTION
This PR will fix this issue: https://github.com/toopay/bootstrap-markdown/issues/41

It give the possibility to:
- Rearrange all buttons & group buttons in whatever order;
- Remove any button that we don't need;
- And of course move the preview button after any additional buttons.

The new option `rearrangeButtons` take an array of values.
In this array we could add:
- A `string`: corresponding to an existing group-name;
- An `object`: containing a name (the object property) + an array of existing button-name (the object value).

Here a complete sample code:

``` js
$("#target-editor-with-custom-buttons").markdown({
  additionalButtons: [
    [{
      name: "groupCustom",
      data: [{
        name: "cmdBeer",
        toggle: true,
        title: "Beer",
        icon: "glyphicon glyphicon-glass",
        callback: function(e){}
      },
      {
        name: 'cmdSave',
        toggle: false,
        title: 'Save',
        icon: 'glyphicon glyphicon-floppy-disk',
        callback: function () {}
      },
      {
        name: 'cmdFullscreen',
        toggle: false,
        title: 'Fullscreen',
        icon: 'glyphicon glyphicon-fullscreen',
        callback: function () {}
      }]
    }]
  ],
  rearrangeButtons: [
    {
      'groupBeer': [
        'cmdBeer'
      ]
    },
    'groupFont',
    'groupLink',
    {
      'groupMisc': [
        'cmdList',
        'cmdSave'
      ]
    },
    {
      'groupUtil': [
        'cmdFullscreen',
        'cmdPreview'
      ]
    }
  ]
})
```

Probably this weekend, I will send another PR to update the documentation on the website.
