### PR TITLE
Add the possibility to use the Bootstrap Modal instead of the JS Prompt

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -864,7 +864,7 @@
                 }
 
             var processLink = function(link) {
-              if (link != null && link != '' && link != 'http://') {
+              if (link && link !== text.placeholder) {
                 // transform selection and set the cursor into chunked text
                 e.replaceSelection('['+chunk+']('+link+')')
                 cursor = selected.start+1


### PR DESCRIPTION
It keeps exactly the same behaviour, but uses the Bootstrap Modal instead on the classic JS prompt.
By default this option is disabled.

E.g.:

``` js
$("#target-editor").markdown({
  useModal: true
})
```
