### PR TITLE
Bump version to 2.3.2.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-markdown",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "main": ["./js/bootstrap-markdown.js", "./css/bootstrap-markdown.min.css"],
   "dependencies": {
     "bootstrap": "~3.1.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-markdown",
   "filename": "js/bootstrap-markdown.js",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A bootstrap plugin for markdown editing",
   "homepage": "https://github.com/toopay/bootstrap-markdown",
   "keywords": [


### PR DESCRIPTION
Could you also tag a new version?
This will help people to get the latest version via [Bower](http://bower.io/search/?q=bootstrap-markdown) or [npm](https://www.npmjs.org/package/bootstrap-markdown).
