### PR TITLE
added initialstate option

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -330,6 +330,10 @@
         this.$editor.addClass('active')
       }
 
+      if (options.initialstate === 'preview') {
+        this.showPreview();
+      }
+
       // Trigger the onShow hook
       options.onShow(this)
 
@@ -730,6 +734,7 @@
     resize: 'none',
     iconlibrary: 'glyph',
     language: 'en',
+    initialstate: 'editor',
 
     /* Buttons Properties */
     buttons: [


### PR DESCRIPTION
I've added an initialstate option, this way you can define the state the new markdown element will be loaded in!

Default it will start with the editor
