### PR TITLE
disable buttons when original element is disabled/readonly

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -321,6 +321,10 @@
         this.$editor.attr('id',(new Date).getTime())
         this.$editor.on('click', '[data-provider="bootstrap-markdown"]', $.proxy(this.__handle, this))
 
+        if (this.$element.is(':disabled') || this.$element.is('[readonly]')) {
+          this.disableButtons('all');
+        }
+
       } else {
         this.$editor.show()
       }


### PR DESCRIPTION
This pr adds the logic to respect the original state of the textarea, when it's disabled or readonly the buttons of the editor should also be disabled. The editor itself already did this correct
