### PR TITLE
fixed case with initialstate and multiple md-editor instances

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -325,6 +325,10 @@
           this.disableButtons('all');
         }
 
+        if (options.initialstate === 'preview') {
+          this.showPreview();
+        }
+
       } else {
         this.$editor.show()
       }
@@ -332,10 +336,6 @@
       if (options.autofocus) {
         this.$textarea.focus()
         this.$editor.addClass('active')
-      }
-
-      if (options.initialstate === 'preview') {
-        this.showPreview();
       }
 
       // Trigger the onShow hook


### PR DESCRIPTION
This PR fixed an bug when using the initial state option on a page with multiple md-editor instances, with this change it will only initilize the initialstate option, if the instance is created for the first time

initialstate option introduced in PR https://github.com/toopay/bootstrap-markdown/pull/64
