### PR TITLE
Added resize option to preview container

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -296,7 +296,7 @@
                               +this.__localize('Save')
                               +'</button>')
 
-          
+
         }
 
         footer = typeof options.footer === 'function' ? options.footer(this) : options.footer
@@ -387,7 +387,7 @@
   , parseContent: function() {
       var content,
         callbackContent = this.$options.onPreview(this) // Try to get the content from callback
-      
+
       if (typeof callbackContent == 'string') {
         // Set the content based by callback content
         content = callbackContent
@@ -436,6 +436,10 @@
         width: container.outerWidth() + 'px',
         height: container.outerHeight() + 'px'
       })
+
+      if (this.$options.resize) {
+        replacementContainer.css('resize',this.$options.resize)
+      }
 
       // Hide the last-active textarea
       container.hide()
@@ -1009,7 +1013,7 @@
               e.replaceSelection('- '+chunk)
               // Set the cursor
               cursor = selected.start+2
-              
+
             } else {
               if (selected.text.indexOf('\n') < 0) {
                 chunk = selected.text
@@ -1056,7 +1060,7 @@
               e.replaceSelection('1. '+chunk)
               // Set the cursor
               cursor = selected.start+3
-              
+
             } else {
               if (selected.text.indexOf('\n') < 0) {
                 chunk = selected.text
@@ -1134,7 +1138,7 @@
               e.replaceSelection('> '+chunk)
               // Set the cursor
               cursor = selected.start+2
-              
+
             } else {
               if (selected.text.indexOf('\n') < 0) {
                 chunk = selected.text


### PR DESCRIPTION
I've added the resize option also to the preview div. This is a new css3 feature which is not supported by all browsers, currently only firefox 4+, chrome 4+, safari4+ (they support also resize on divs), opera 12.1+ only supports resize on textarea's, but support should come

see: [Can you run it: Resize](http://caniuse.com/css-resize)

So this is a feature what will eventualy be supported in all browsers, but it is a nice-to-have in the current browser who support this!
