### PR TITLE
remove option merge by full dom data

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -30,7 +30,7 @@
     this.$ns           = 'bootstrap-markdown'
     this.$element      = $(element)
     this.$editable     = {el:null, type:null,attrKeys:[], attrValues:[], content:null}
-    this.$options      = $.extend(true, {}, $.fn.markdown.defaults, options, this.$element.data(), this.$element.data('options'))
+    this.$options      = $.extend(true, {}, $.fn.markdown.defaults, options, this.$element.data('options'))
     this.$oldContent   = null
     this.$isPreview    = false
     this.$isFullscreen = false


### PR DESCRIPTION
Hi

I tested bootstrap-markdown with requireJS by below code

``` js
(function(root, factory){
    if (typeof define === 'function' && define.amd) {
        require(["jquery", "bootstrap-markdown"], factory);
    } else {
        factory(root.jQuery);
    }
})(this, function($){
    $("#content").markdown();
});
```
But found that console got a "Uncaught Range Error: Maximum call stack size exceeded", By tracking the code I found that when create editor option, it merged full dom data() object and make this issue caused. Please confirm.