### PR TITLE
Enable preview button while the editor is disabled

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -371,7 +371,7 @@
 
         if (this.$element.is(':disabled') || this.$element.is('[readonly]')) {
           this.$editor.addClass('md-editor-disabled');
-          this.disableButtons('all');
+          this.disableButtons('all').enableButtons('cmdPreview');
         }
 
         if (this.eventSupported('keydown') && typeof jQuery.hotkeys === 'object') {
@@ -491,7 +491,7 @@
 
       if (this.$element.is(':disabled') || this.$element.is('[readonly]')) {
         this.$editor.addClass('md-editor-disabled');
-        this.disableButtons('all');
+        this.disableButtons('all').enableButtons('cmdPreview');
       }
 
       return this
@@ -515,6 +515,11 @@
       // Back to the editor
       this.$textarea.show()
       this.__setListener()
+
+      if (this.$element.is(':disabled') || this.$element.is('[readonly]')) {
+        this.$editor.addClass('md-editor-disabled');
+        this.disableButtons('all').enableButtons('cmdPreview');
+      }
 
       return this
     }


### PR DESCRIPTION
Hi, 

I want to disable the editor as default, so that the user have to enable the editor before he change the content. But I found no way to enable the editor while it's disabled. I think the preview button just changes the content format, therefore, it should be always enabled. on the other hand, if hidePreview function doesn't check disabled and readonly, the other buttons can still work even if the textarea has been disabled which I think is a little bit weird.

Please confirm.

Thanks!