### PR TITLE
support a comma-separated list of button names

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -654,7 +654,7 @@
       var buttons = []
 
       if (typeof nameParam == 'string') {
-        buttons.push(nameParam)
+        buttons = nameParam.split(',')
       } else {
         buttons = nameParam
       }


### PR DESCRIPTION
Previously, only a single button could be disabled via the attribute when 
set in the HTML without the help of JS.  Now, the attribute accepts a
comma-separated list of button names so that more than one button
can be simultaneously hidden.
