### PR TITLE
Fix unsupported plural of `repository` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "name": "Taufan Aditya",
     "web": "https://github.com/toopay"
   }],
-  "repositories": [{
+  "repository": {
     "type": "git",
     "url": "https://github.com/toopay/bootstrap-markdown.git"
-  }]
+  }
 }


### PR DESCRIPTION
Applies to [npmjs.com](https://www.npmjs.com/) and [nodejs.org](http://nodejs.org/).

Reference:
* https://docs.npmjs.com/files/package.json#repository

Warning:

``` sh-session
$ npm install bootstrap-markdown
npm WARN package.json bootstrap-markdown@2.8.0 'repositories' (plural) Not supported. Please pick one as the 'repository' field
```

Thank you for this consideration.