### PR TITLE
Support any markdown parser via option

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -444,7 +444,9 @@
       // parse with supported markdown parser
       var val = val || this.$textarea.val();
 
-      if (typeof markdown == 'object') {
+      if (this.$options.parser) {
+        content = this.$options.parser(val);
+      } else if (typeof markdown == 'object') {
         content = markdown.toHTML(val);
       } else if (typeof marked == 'function') {
         content = marked(val);
@@ -843,7 +845,7 @@
             // Build the original element
             var oldElement = $('<'+editable.type+'/>'),
                 content = this.getContent(),
-                currentContent = (typeof markdown == 'object') ? markdown.toHTML(content) : content;
+                currentContent = this.parseContent(content);
 
             $(editable.attrKeys).each(function(k,v) {
               oldElement.attr(editable.attrKeys[k],editable.attrValues[k]);
@@ -887,13 +889,14 @@
     /* Editor Properties */
     autofocus: false,
     hideable: false,
-    savable:false,
+    savable: false,
     width: 'inherit',
     height: 'inherit',
     resize: 'none',
     iconlibrary: 'glyph',
     language: 'en',
     initialstate: 'editor',
+    parser: null,
 
     /* Buttons Properties */
     buttons: [


### PR DESCRIPTION
This permits any parser to be used regardless of its interface.  My reason for wanting this is that I'd like to use [markdown-it](https://github.com/markdown-it/markdown-it) since it is stricter, as both [markdown.js](https://github.com/evilstreak/markdown-js) and [marked](https://github.com/chjj/marked) share the same [XSS vulnerability](https://github.com/evilstreak/markdown-js/issues/235).  The problem is that markdownit is not referred to as `markdown` or `marked` in the window namespace, and its function for converting markdown to HTML is named `render` rather than `toHTML`.

This change will allow a new `parse` option to be supplied when calling bootstrap-markdown's `$.fn.markdown` method, which is a function definition that is called in place of the existing options.  (I maintained the existing options for backward compatibility.)  For example:

```javascript
var md = markdownit();

$('[data-provide="markdown-editor"][data-preview]').markdown({
  parser: md.render.bind(md),
  onChange: function (e) {
    var $preview = $(e.$textarea.data('preview'));
    $preview.html(e.parseContent());
  }
});
```