### PR TITLE
Fixed events config

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -161,15 +161,19 @@
         this.$textarea.css('resize',this.$options.resize);
       }
 
-      this.$textarea
-        .on('focus',    $.proxy(this.focus, this))
-        .on('keypress', $.proxy(this.keypress, this))
-        .on('keyup',    $.proxy(this.keyup, this))
-        .on('change',   $.proxy(this.change, this))
-        .on('select',   $.proxy(this.select, this));
+      this.$textarea.on({
+          'focus' : $.proxy(this.focus, this),
+          'keyup' : $.proxy(this.keyup, this),
+          'change' : $.proxy(this.change, this),
+          'select' : $.proxy(this.select, this)
+      });
 
       if (this.eventSupported('keydown')) {
         this.$textarea.on('keydown', $.proxy(this.keydown, this));
+      }
+
+      if (this.eventSupported('keypress')) {
+        this.$textarea.on('keypress', $.proxy(this.keypress, this))
       }
 
       // Re-attach markdown data


### PR DESCRIPTION
Fixed issue with an undefined keypress, first check before adding the event listener.

Jquery 2.2.0 introduced a bug that caused this issue to come up. But as @mgol pointed out in #125 (https://github.com/toopay/bootstrap-markdown/issues/215#issuecomment-171656285) passing undefined events is not allowed (2.2.0 gave an exception but was not planning, 3.0 will reject this behavior)

2.2.1 will fix this exception but from jquery 3.* it will throw the exception again. So this PR fixes compatibiltiy with jquery 3 and makes the jquery 2.2.0 version back usable!

Closes #215