### PR TITLE
Specify the main js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-markdown",
-  "filename": "js/bootstrap-markdown.js",
+  "main": "js/bootstrap-markdown.js",
   "version": "2.10.0",
   "description": "A bootstrap plugin for markdown editing",
   "license" : "Apache-2.0",


### PR DESCRIPTION
The default js file is not specified, we want to use main to specify where it is. 

This will fix https://github.com/toopay/bootstrap-markdown/issues/239 