### PR TITLE
Allow drag and drop Images and embed as data-uri

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -489,6 +489,25 @@
         }
       }
 
+      // enable data-uris via drag and drop
+      if (options.enableDropDataUri === true) {
+        this.$editor.on('drop', function(e) {
+          var caretPos = textarea.prop('selectionStart');
+          e.stopPropagation();
+          e.preventDefault();
+          $.each(e.originalEvent.dataTransfer.files, function(index, file){
+            var fileReader = new FileReader();
+              fileReader.onload = (function(file) {
+                 return function(e) {
+                    var text = textarea.val();
+                    textarea.val(text.substring(0, caretPos) + '\n<img src="'+ e.target.result  +'" />\n' + text.substring(caretPos) );
+                 };
+              })(file);
+            fileReader.readAsDataURL(file);
+          });
+        });
+      }
+
       // Trigger the onShow hook
       options.onShow(this);
 
@@ -956,6 +975,7 @@
     initialstate: 'editor',
     parser: null,
     dropZoneOptions: null,
+    enableDropDataUri: false,
 
     /* Buttons Properties */
     buttons: [


### PR DESCRIPTION
This adds the feature for enabling drag and drop of images, and put them as simple html, with data-uris. 

As markdown itself allows HTML, this makes easy to have the content all together on the same document: in my use case my documents get completely (with images too) saved on the mongodb, and later my backups are easy to restore (no external image files for each document)

@toopay hope you see this as a nice addition? Cheers!