### PR TITLE
Use glyphicon-console by default for cmdCode button

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -1256,7 +1256,7 @@
           hotkey: 'Ctrl+K',
           title: 'Code',
           icon: {
-            glyph: 'glyphicon glyphicon-asterisk',
+            glyph: 'glyphicon glyphicon-console',
             fa: 'fa fa-code',
             'fa-3': 'icon-code',
             octicons: 'octicon octicon-code'


### PR DESCRIPTION
I think `glyphicon-console` is more expressive for the code button than `glyphicon-star`.

Here's how it looks:

![bootstrap-markdown-console](https://cloud.githubusercontent.com/assets/3429231/16557986/278275c4-41e3-11e6-889a-a3818965ffbf.png)

(P.S.: preview and write tabs are custom)