### PR TITLE
Fix language sorthand for danish language

### DIFF
--- a/locale/bootstrap-markdown.da.js
+++ b/locale/bootstrap-markdown.da.js
@@ -3,7 +3,7 @@
  * Dan Storm <storm@catalystcode.net>
  */
 (function ($) {
-  $.fn.markdown.messages.nb = {
+  $.fn.markdown.messages.da = {
     'Bold': 'Fed',
     'Italic': 'Kursiv',
     'Heading': 'Overskrift',


### PR DESCRIPTION
Danish language is not `nl` in it's iso-countrycode it's `da`