### PR TITLE
Added buttonSize option to set general buttons size

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -95,8 +95,28 @@
     __buildButtons: function(buttonsArray, container) {
       var i,
         ns = this.$ns,
+        buttonSize = this.$options.buttonSize,
         handler = this.$handler,
         callback = this.$callback;
+
+        if( typeof buttonSize !== 'undefined') {
+          switch(buttonSize){
+            case 'large':
+              buttonSize = ' btn-lg';
+            break;
+            case 'normal':
+              buttonSize = '';
+            break;
+            case 'small':
+              buttonSize = ' btn-sm';
+            break;
+            default:
+              buttonSize = ' btn-sm';
+            break;
+          }
+        }else{
+          buttonSize = ' btn-sm';
+        }
 
       for (i = 0; i < buttonsArray.length; i++) {
         // Build each group container
@@ -122,7 +142,7 @@
 
             // Construct the button object
             buttonContainer = $('<button></button>');
-            buttonContainer.text(' ' + this.__localize(btnText)).addClass('btn-default btn-sm').addClass(btnClass);
+            buttonContainer.text(' ' + this.__localize(btnText)).addClass('btn-default' + buttonSize).addClass(btnClass);
             if (btnClass.match(/btn\-(primary|success|info|warning|danger|link)/)) {
               buttonContainer.removeClass('btn-default');
             }
@@ -1378,7 +1398,7 @@
           hotkey: 'Ctrl+P',
           title: 'Preview',
           btnText: 'Preview',
-          btnClass: 'btn btn-primary btn-sm',
+          btnClass: 'btn btn-primary',
           icon: {
             glyph: 'glyphicon glyphicon-search',
             fa: 'fa fa-search',


### PR DESCRIPTION
Added support to change the default `btn-sm` button size class, in our design `btn-sm` is really small so I wanted to give it the option to change the global buttons size without affecting the current behavior:

```
$("#some-textarea").markdown({
  buttonSize: 'large'
});
```

It accepts there different values: `normal, large, small` and by default it keeps setting `btn-sm`, what do you think?