### PR TITLE
Simple fix for correcting the path url for dropzone markdown images

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -479,7 +479,7 @@
                   });
               this.on('success', function(file, path) {
                   var text = textarea.val();
-                  textarea.val(text.substring(0, caretPos) + '\n![description](' + path + ')\n' + text.substring(caretPos));
+                  textarea.val(text.substring(0, caretPos) + '\n![description](' + path.url + ')\n' + text.substring(caretPos));
                   });
               this.on('error', function(file, error, xhr) {
                   console.log('Error:', error);


### PR DESCRIPTION
I don't know if this was changed or not with dropzone in their later versions from when this was first implemented, but the `path` is actually an object, thus we need `path.url` to correctly print the associated url for the file that was uploaded.