### PR TITLE
Add ability to set custom icons

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -113,7 +113,7 @@
             var button = buttons[z],
               buttonContainer, buttonIconContainer,
               buttonHandler = ns + '-' + button.name,
-              buttonIcon = this.__getIcon(button.icon),
+              buttonIcon = this.__getIcon(button),
               btnText = button.btnText ? button.btnText : '',
               btnClass = button.btnClass ? button.btnClass : 'btn',
               tabIndex = button.tabIndex ? button.tabIndex : '-1',
@@ -222,7 +222,12 @@
       return string;
     },
     __getIcon: function(src) {
-      return typeof src == 'object' ? src[this.$options.iconlibrary] : src;
+      if(typeof src == 'object'){
+        var customIcon = this.$options.customIcons[src.name];
+        return typeof customIcon == 'undefined' ? src.icon[this.$options.iconlibrary] : customIcon;
+      } else {
+        return src;
+      }
     },
     setFullscreen: function(mode) {
       var $editor = this.$editor,
@@ -1378,6 +1383,7 @@
         }]
       }]
     ],
+    customIcons: {},
     additionalButtons: [], // Place to hook more buttons by code
     reorderButtonGroups: [],
     hiddenButtons: [], // Default hidden buttons
@@ -1387,16 +1393,22 @@
       enable: true,
       icons: {
         fullscreenOn: {
-          fa: 'fa fa-expand',
-          glyph: 'glyphicon glyphicon-fullscreen',
-          'fa-3': 'icon-resize-full',
-          octicons: 'octicon octicon-link-external'
+          name: "fullscreenOn",
+          icon: {
+            fa: 'fa fa-expand',
+            glyph: 'glyphicon glyphicon-fullscreen',
+            'fa-3': 'icon-resize-full',
+            octicons: 'octicon octicon-link-external'
+          }
         },
         fullscreenOff: {
-          fa: 'fa fa-compress',
-          glyph: 'glyphicon glyphicon-fullscreen',
-          'fa-3': 'icon-resize-small',
-          octicons: 'octicon octicon-browser'
+          name: "fullscreenOff",
+          icon: {
+            fa: 'fa fa-compress',
+            glyph: 'glyphicon glyphicon-fullscreen',
+            'fa-3': 'icon-resize-small',
+            octicons: 'octicon octicon-browser'
+          }
         }
       }
     },


### PR DESCRIPTION
The user can now set custom icon by setting the `customIcons` option:

``` js
$("#textarea").markdown({
  customIcons: {
    "cmdBold": "glyphicon glyphicon-envelope"
  }
}
```

We need this option on diaspora as we use some custom icons:

![bs-md](https://cloud.githubusercontent.com/assets/3429231/19222267/ac6eb76c-8e54-11e6-8b45-dcba7edec0df.png)

It is currently done the ugly way, _i.e._: we replace button classes after instanciation.
