### PR TITLE
Change preview content height setting

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -580,8 +580,9 @@
 
       // Set the preview element dimensions
       replacementContainer.css({
-        width: container.outerWidth() + 'px',
-        height: container.outerHeight() + 'px'
+        "width": container.outerWidth() + 'px',
+        "min-height": container.outerHeight() + 'px',
+        "height": "auto"
       });
 
       if (this.$options.resize) {


### PR DESCRIPTION
Sets `min-height` rather than `height` and sets `height` to `auto`. This improves the preview look. Container will then never be smaller than textarea but will still adapt to the preview content height. Currently, as the height is hardwired, if the preview content is higher than the textarea, a scrollbar appears.