### PR TITLE
Add list continuation on 'Enter' press functionality & fix extra event listener bug

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -167,6 +167,10 @@
         this.$textarea.css('resize', this.$options.resize);
       }
 
+      // Re-attach markdown data
+      this.$textarea.data('markdown', this);
+    },
+    __setEventListeners: function() {
       this.$textarea.on({
         'focus': $.proxy(this.focus, this),
         'keyup': $.proxy(this.keyup, this),
@@ -181,9 +185,6 @@
       if (this.eventSupported('keypress')) {
         this.$textarea.on('keypress', $.proxy(this.keypress, this));
       }
-
-      // Re-attach markdown data
-      this.$textarea.data('markdown', this);
     },
     __handle: function(e) {
       var target = $(e.currentTarget),
@@ -418,6 +419,7 @@
         this.$oldContent = this.getContent();
 
         this.__setListener();
+        this.__setEventListeners();
 
         // Set editor attributes, data short-hand API and listener
         this.$editor.attr('id', (new Date()).getTime());


### PR DESCRIPTION
Thanks for the work on this great library!

### Continue list on 'Enter' press
The first commit in this PR (5ecd7a2) adds functionality for continuing a numbered or bulleted list by pressing 'Enter'. 
For clarity, here's the current behavior around lists when one presses 'Enter': https://d.pr/HmKAwL
And here's the addition my code makes: https://d.pr/wz5Jx
(also see Issue: `unexpected behaviour: list/quote items not carried to next line` #171 for context) 

### Fix multiple event listeners bug
Secondly, when working on this PR, I realized that there is a bug in the way that event listeners are being handled. Currently, every time that `hidePreview` is called, the `__setListener()` appends all of the event listeners again. Thus, after clicking back and forth between the 'Preview' screen a few times, we end up with many extra listeners. 

By adding a `console.log` statement inside one of the event listeners (such as underneath line 822), we can see this happening. This video shows how initially the listener event is only being invoked once, as it should be, but for every time that we show and hide the 'Preview', an additional listener is added (and thus invoked on the down arrow keypress): https://d.pr/Xtl7jR 

My second commit in this PR (c3907a9) implements a fix by only setting the keypress listeners when the editor is initialized. 

---

I'm more than happy to take feedback on this PR and make revisions as desired. It'd be wonderful to see a new release of this package that includes all of the fixes that have been implemented since January 2016 too! Thanks again for your work on this.
