### PR TITLE
Dont add a bullet after a horizontal rule

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -874,6 +874,10 @@
             }
           }
 
+          if (chars.slice(priorNewlineIndex + 1, priorNewlineIndex + 4).join('') == '---') {
+            break;
+          }
+
           var charFollowingLastLineBreak = chars[priorNewlineIndex + 1];
           if (charFollowingLastLineBreak === '-') {
             this.addBullet(enterIndex);


### PR DESCRIPTION
After adding a horizontal rule (`---`), a bullet is inserted automatically after hitting the Enter key. I'm not sure if this is intended behavior but here is a PR to fix it in case its a bug.

I've attached a GIF to further explain the behavior:

![aug-20-2018 18-02-03](https://user-images.githubusercontent.com/1901520/44334084-31630e80-a4a3-11e8-8bba-cbfc05eab967.gif)
