### PR TITLE
Fix edit buttons not triggering change events

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -200,7 +200,7 @@
       callbackHandler(this);
 
       // Trigger onChange for each button handle
-      this.change(this);
+      this.$textarea.change();
 
       // Unless it was the save handler,
       // focusin the textarea


### PR DESCRIPTION
The discussion in #308 indicates that `this.change(this)` is incorrect, adding a listener instead of triggering a change event.

closes #308.