### PR TITLE
Close bullet list after hitting enter on empty list line

### DIFF
--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -880,7 +880,17 @@
 
           var charFollowingLastLineBreak = chars[priorNewlineIndex + 1];
           if (charFollowingLastLineBreak === '-') {
-            this.addBullet(enterIndex);
+            var line = chars.slice(priorNewlineIndex + 2, enterIndex).join('');
+            var allWhitespace = /^[\W]*$/.test(line);
+            if (allWhitespace) {
+              // If we hit enter on a empty line, we probably want to close the bullet list
+              var linesDeleted = line.length + 2;
+              this.setSelection(priorNewlineIndex, enterIndex);
+              this.replaceSelection("\n\n");
+              this.setSelection(enterIndex + 2 - linesDeleted, enterIndex + 2 - linesDeleted); // Put the cursor into new line
+            } else {
+              this.addBullet(enterIndex);
+            }
           } else if ($.isNumeric(charFollowingLastLineBreak)) {
               var numBullet = this.getBulletNumber(priorNewlineIndex + 1);
               if (numBullet) {

--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -892,10 +892,20 @@
               this.addBullet(enterIndex);
             }
           } else if ($.isNumeric(charFollowingLastLineBreak)) {
-              var numBullet = this.getBulletNumber(priorNewlineIndex + 1);
-              if (numBullet) {
+            var numBullet = this.getBulletNumber(priorNewlineIndex + 1);
+            if (numBullet) {
+              var line = chars.slice(priorNewlineIndex + 1, enterIndex).join('');
+              var allWhitespace = (new RegExp('^' + numBullet + '\\.[\\W]*$')).test(line);
+              if (allWhitespace) {
+                // If we hit enter on a empty line, we probably want to close the numbered bullet list
+                var linesDeleted = line.length;
+                this.setSelection(priorNewlineIndex, enterIndex);
+                this.replaceSelection("\n\n");
+                this.setSelection(enterIndex + 1 - linesDeleted, enterIndex + 1 - linesDeleted); // Put the cursor into new line
+              } else {
                 this.addNumberedBullet(enterIndex, numBullet);
               }
+            }
           }
           break;
 

--- a/js/bootstrap-markdown.js
+++ b/js/bootstrap-markdown.js
@@ -938,7 +938,7 @@
       var numBullet = (num + 1) + '. \n';
       this.insertContent(index, numBullet);
 
-      var prefixLength = num.toString().length + 2;
+      var prefixLength = (num + 1).toString().length + 2;
       this.setSelection(index + prefixLength, index + prefixLength); // Put the cursor after the number
     },
     getBulletNumber: function(startIndex) {


### PR DESCRIPTION
Since I like this convenience on every markdown editor I go, I thought I add this here too. This adds the following behavior:

Hitting enter on empty list rows, will close the (numbered) bullet list.

### Here an example:

When having the following content in a textarea (`|` is representing the caret):
```
- list 1
- |

something more...
```

After hitting enter the content will now look like this:

```
- list 1

|

something more...
```

instead of this:
```
- list 1
- 
- |

something more...
```

I added the same for numbered bullet lists.

As a bonus, I also fixed the bug, that hitting enter on  a line like `9. ` will misplace the caret about one character, since the length of the old number was used, instead of the added `10.`.

### Note about testing:

Since there are no tests in this repository, I tested all the cases I could come up with manually. 

If something is missing, or you want to have something changed. I am eager to do it. I would like to have this feature in. :)